### PR TITLE
Move responsibility to inject IJSRuntime to IApplicationInsights from IOC container to ApplicationInsightsComponent

### DIFF
--- a/src/BlazorApplicationInsights/ApplicationInsights.cs
+++ b/src/BlazorApplicationInsights/ApplicationInsights.cs
@@ -7,11 +7,11 @@ namespace BlazorApplicationInsights
 {
     public class ApplicationInsights : IApplicationInsights
     {
-        private readonly IJSRuntime JSRuntime;
+        private IJSRuntime? JSRuntime { get; set; }
 
-        public ApplicationInsights(IJSRuntime jsRuntime)
+        public void InitJSRuntime(IJSRuntime jSRuntime)
         {
-            JSRuntime = jsRuntime;
+            JSRuntime = jSRuntime;
         }
 
         public async Task TrackPageView(string? name = null, string? uri = null, string? refUri = null, string? pageType = null, bool? isLoggedIn = null, Dictionary<string, object>? properties = null)

--- a/src/BlazorApplicationInsights/ApplicationInsightsComponent.razor.cs
+++ b/src/BlazorApplicationInsights/ApplicationInsightsComponent.razor.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.JSInterop;
 
 namespace BlazorApplicationInsights
 {
@@ -7,9 +8,12 @@ namespace BlazorApplicationInsights
     {
         [Inject] private IApplicationInsights ApplicationInsights { get; set; }
         [Inject] private NavigationManager NavigationManager { get; set; }
+        [Inject] private IJSRuntime JSRuntime { get; set; }
 
         protected override void OnInitialized()
         {
+            ApplicationInsights.InitJSRuntime(JSRuntime);
+
             NavigationManager.LocationChanged += NavigationManager_LocationChanged;
         }
 

--- a/src/BlazorApplicationInsights/IApplicationInsights.cs
+++ b/src/BlazorApplicationInsights/IApplicationInsights.cs
@@ -1,11 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.JSInterop;
 
 namespace BlazorApplicationInsights
 {
     public interface IApplicationInsights
     {
+        /// <summary>
+        /// Init IJSRuntime
+        /// </summary>
+        /// <param name="jSRuntime"></param>
+        void InitJSRuntime(IJSRuntime jSRuntime);
+
         /// <summary>
         /// Log a user action or other occurrence.
         /// </summary>


### PR DESCRIPTION
Hi,

This change allows using this super handy library from the blazor-server.
  
Now, when I try to register `services.AddBlazorApplicationInsights();` I got Exception: circular dependency of service. 

Under .NET 5, problem is circle: Service -> IJSRuntime -> Logger -> BlazorApplicationInsights lib  logger -> IJSRuntime

 
