### PR TITLE
ApplicationInsightsComponent.Dispose()

### DIFF
--- a/src/BlazorApplicationInsights/ApplicationInsightsComponent.razor.cs
+++ b/src/BlazorApplicationInsights/ApplicationInsightsComponent.razor.cs
@@ -1,11 +1,12 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.JSInterop;
 
 namespace BlazorApplicationInsights
 {
-    public partial class ApplicationInsightsComponent
+    public partial class ApplicationInsightsComponent : IDisposable
     {
         [Inject] private IApplicationInsights ApplicationInsights { get; set; }
         [Inject] private NavigationManager NavigationManager { get; set; }
@@ -28,5 +29,10 @@ namespace BlazorApplicationInsights
         {
             await ApplicationInsights.TrackPageView();
         }
-    }
+
+		public void Dispose()
+		{
+			NavigationManager.LocationChanged -= NavigationManager_LocationChanged;
+		}
+	}
 }


### PR DESCRIPTION
Unsubscribe from NavigationManager.LocationChanged event.

(Although you might not expect the component will be ever disposed. But you never know...)