### PR TITLE
Update

### DIFF
--- a/src/BlazorApplicationInsights.Sample/Program.cs
+++ b/src/BlazorApplicationInsights.Sample/Program.cs
@@ -27,6 +27,9 @@ namespace BlazorApplicationInsights.Sample
                     }
                 };
 
+                await applicationInsights.SetInstrumentationKey("219f9af4-0842-42c8-a5b1-578f09d2ee27");
+                await applicationInsights.LoadAppInsights();
+
                 await applicationInsights.AddTelemetryInitializer(telemetryItem);
             });
 

--- a/src/BlazorApplicationInsights.Sample/wwwroot/index.html
+++ b/src/BlazorApplicationInsights.Sample/wwwroot/index.html
@@ -11,9 +11,7 @@
             src: "https://js.monitor.azure.com/scripts/b/ai.2.min.js",
             ld: -1,
             crossOrigin: "anonymous",
-            cfg: {
-                instrumentationKey: "219f9af4-0842-42c8-a5b1-578f09d2ee27"
-            }
+            cfg: {}
         });
     </script>
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />

--- a/src/BlazorApplicationInsights.Tests/BlazorApplicationInsights.Tests.csproj
+++ b/src/BlazorApplicationInsights.Tests/BlazorApplicationInsights.Tests.csproj
@@ -8,14 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="PlaywrightSharp" Version="0.180.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="PlaywrightSharp" Version="0.192.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/BlazorApplicationInsights.Tests/UnitTests.cs
+++ b/src/BlazorApplicationInsights.Tests/UnitTests.cs
@@ -25,7 +25,7 @@ namespace BlazorApplicationInsights.Tests
         [InlineData("TrackEvent", false, 2)]
         [InlineData("TrackTrace", false, 4)]
         [InlineData("TrackException", false, 2)]
-        [InlineData("TrackGlobalException", true, 1)]
+        [InlineData("TrackGlobalException", false, 1)]
         [InlineData("SetAuthenticatedUserContext", false, 1)]
         [InlineData("ClearAuthenticatedUserContext", false, 1)]
         [InlineData("StartStopTrackPage", false, 1)]
@@ -47,7 +47,7 @@ namespace BlazorApplicationInsights.Tests
 
             page.Console += (sender, e) =>
             {
-                if (e.Message.Type == "error")
+                if (e.Message.Type == "error" && !e.Message.Text.Contains("Something wrong happened :("))
                 {
                     hasError = true;
                 }
@@ -73,6 +73,61 @@ namespace BlazorApplicationInsights.Tests
 
             hasError.Should().Be(shouldError);
             appInsightsCalls.Should().Be(expectedCalls);
+        }
+
+        [Theory]
+        [InlineData("TrackEvent", false)]
+        [InlineData("TrackTrace", false)]
+        [InlineData("TrackException", false)]
+        [InlineData("TrackGlobalException", false)]
+        [InlineData("SetAuthenticatedUserContext", false)]
+        [InlineData("ClearAuthenticatedUserContext", false)]
+        [InlineData("StartStopTrackPage", false)]
+        [InlineData("TrackDependencyData", false)]
+        [InlineData("TrackMetric", false)]
+        [InlineData("TrackPageView", false)]
+        [InlineData("TrackPageViewPerformance", false)]
+        [InlineData("TestLogger", false)]
+        [InlineData("StartStopTrackEvent", false)]
+        public async Task TestBlocked(string id, bool shouldError)
+        {
+            bool hasError = false;
+
+            using var playwright = await Playwright.CreateAsync();
+
+            await using var browser = await playwright.Chromium.LaunchAsync(Headless);
+            var page = await browser.NewPageAsync();
+
+            page.Console += (sender, e) =>
+            {
+                if (e.Message.Type == "error" && e.Message.Text != "Failed to load resource: net::ERR_FAILED" && !e.Message.Text.Contains("Something wrong happened :("))
+                {
+                    hasError = true;
+                }
+            };
+
+            await page.RouteAsync("https://dc.services.visualstudio.com/v2/track", async (x, y )  => {
+                await x.AbortAsync();
+            });
+
+            await page.RouteAsync("https://js.monitor.azure.com/scripts/b/ai.2.min.js", async (x, y) => {
+                await x.AbortAsync();
+            });
+
+            page.RequestFailed += (sender, e) =>
+            {
+                if (e.Request.Url != "https://js.monitor.azure.com/scripts/b/ai.2.min.js" && e.Request.Url != "https://dc.services.visualstudio.com/v2/track")
+                {
+                    hasError = true;
+                }
+            };
+
+            await page.GoToAsync(BaseAddress);
+            await page.ClickAsync("#" + id);
+
+            await page.WaitForTimeoutAsync(1000);
+
+            hasError.Should().Be(shouldError);
         }
     }
 }

--- a/src/BlazorApplicationInsights/wwwroot/JsInterop.js
+++ b/src/BlazorApplicationInsights/wwwroot/JsInterop.js
@@ -71,6 +71,8 @@
         appInsights.config.instrumentationKey = instrumentationKey;
     },
     loadAppInsights: function () {
-        appInsights.loadAppInsights();
+        if (appInsights.loadAppInsights !== undefined) {
+            appInsights.loadAppInsights();
+        }
     },
 };


### PR DESCRIPTION
prevent exceptions when JS is not loaded, fixed #72 
added tests for when JS is not loaded
update dotnet to v3.1.14
sample, switched to setting key programmatically
