### PR TITLE
feat: support semantic logging

### DIFF
--- a/src/BlazorApplicationInsights.Sample/Pages/Index.razor
+++ b/src/BlazorApplicationInsights.Sample/Pages/Index.razor
@@ -33,6 +33,8 @@
 <br />
 <button class="btn btn-primary" @onclick="TestLogger" id="TestLogger">Test Logger</button>
 <br />
+<button class="btn btn-primary" @onclick="TestSemanticLogger" id="TestSemanticLogger">Test Semantic Logger</button>
+<br />
 <button class="btn btn-primary" @onclick="StartStopTrackEvent" id="StartStopTrackEvent">Start/Stop Track Event</button>
 <br />
 <button class="btn btn-primary" @onclick="SetInstrumentationKey" id="SetInstrumentationKey">Set Instrumentation Key</button>

--- a/src/BlazorApplicationInsights.Sample/Pages/Index.razor.cs
+++ b/src/BlazorApplicationInsights.Sample/Pages/Index.razor.cs
@@ -91,6 +91,12 @@ namespace BlazorApplicationInsights.Sample.Pages
             await AppInsights.Flush();
         }
 
+        private async Task TestSemanticLogger()
+        {
+            Logger.LogInformation("My Semantic Logging Test with customProperty={customProperty}", "customValue");
+            await AppInsights.Flush();
+        }
+
         private async Task StartStopTrackEvent()
         {
             await AppInsights.StartTrackEvent("myEvent");

--- a/src/BlazorApplicationInsights.Tests/UnitTests.cs
+++ b/src/BlazorApplicationInsights.Tests/UnitTests.cs
@@ -34,6 +34,7 @@ namespace BlazorApplicationInsights.Tests
         [InlineData("TrackPageView", false, 2)]
         [InlineData("TrackPageViewPerformance", false, 2)]
         [InlineData("TestLogger", false, 2)]
+        [InlineData("TestSemanticLogger", false, 2)]
         [InlineData("StartStopTrackEvent", false, 2)]
         public async Task Test(string id, bool shouldError, int expectedCalls)
         {
@@ -88,6 +89,7 @@ namespace BlazorApplicationInsights.Tests
         [InlineData("TrackPageView", false)]
         [InlineData("TrackPageViewPerformance", false)]
         [InlineData("TestLogger", false)]
+        [InlineData("TestSemanticLogger", false)]
         [InlineData("StartStopTrackEvent", false)]
         public async Task TestBlocked(string id, bool shouldError)
         {

--- a/src/BlazorApplicationInsights/Logging/ApplicationInsightsLogger.cs
+++ b/src/BlazorApplicationInsights/Logging/ApplicationInsightsLogger.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 
 namespace BlazorApplicationInsights
 {
@@ -34,6 +36,7 @@ namespace BlazorApplicationInsights
         {
             SeverityLevel severityLevel = SeverityLevel.Verbose;
             var msg = formatter(state, exception);
+            var properties = GetProperties(state);
 
             switch (logLevel)
             {
@@ -58,12 +61,25 @@ namespace BlazorApplicationInsights
 
             if (exception != null)
             {
-                ApplicationInsights.TrackException(new Error() { Name = exception.GetType().Name, Message = exception.ToString() }, null, severityLevel);
+                ApplicationInsights.TrackException(new Error() { Name = exception.GetType().Name, Message = exception.ToString() }, null, severityLevel, properties);
             }
             else
             {
-                ApplicationInsights.TrackTrace(msg, severityLevel, null);
+                ApplicationInsights.TrackTrace(msg, severityLevel, properties);
             }
+        }
+        
+        private Dictionary<string, object>? GetProperties<TState>(TState state)
+        {
+            var properties = state as IReadOnlyList<KeyValuePair<string, object>>;
+            if (properties == null)
+                return null;
+            
+            Dictionary<string, object> dict = new Dictionary<string, object>();
+            foreach (KeyValuePair<string, object> item in properties)
+                dict[item.Key] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
+
+            return dict;
         }
     }
 


### PR DESCRIPTION
When using a message template, the arguments are now sent to application insights as Custom Properties. This makes it easier to query the log statements, [ref](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-5.0#log-message-template).