### PR TITLE
fix: Concatenate telemetry initializer data and method data

### DIFF
--- a/src/BlazorApplicationInsights/wwwroot/JsInterop.js
+++ b/src/BlazorApplicationInsights/wwwroot/JsInterop.js
@@ -20,7 +20,7 @@
                 envelope.tags = telemetryItem.tags;
             }
             if (telemetryItem.data !== null) {
-                envelope.data = telemetryItem.data;
+                Object.assign(envelope.data, telemetryItem.data);
             }
             if (telemetryItem.baseType !== null) {
                 envelope.baseType = telemetryItem.baseType;


### PR DESCRIPTION
This allows for setting some custom data to be passed in every telemetry request and also in custom properties on track method calls, e.g.:

```cs
var telemetryItem = new TelemetryItem()
{
    Tags = new Dictionary<string, object>()
    {
        { "ai.cloud.role", "SPA" },
        { "ai.cloud.roleInstance", "Blazor Wasm" },
    },
    Data = new Dictionary<string, object>
    {
        { "UserName", User?.Name ?? "" },
        { "UserEmail", User?.Email ?? "" },
        { "UserId", User?.UserId ?? Guid.Empty },
    }
};

await appInsights.AddTelemetryInitializer(telemetryItem);

await appInsights.TrackEvent("App Started", new Dictionary<string, object>()
{
    { "EnabledModules", true },
    { "ClientVersion", "1.2.3.4" }
});
```

Without this change, only `UserName`, `UserEmail`, and `UserId` would be included in the `App Started` event.