### PR TITLE
Bugfix for overriding settings

### DIFF
--- a/src/BlazorApplicationInsights/ApplicationInsights.cs
+++ b/src/BlazorApplicationInsights/ApplicationInsights.cs
@@ -2,6 +2,7 @@
 using BlazorApplicationInsights.Models;
 using Microsoft.JSInterop;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace BlazorApplicationInsights;
@@ -79,7 +80,16 @@ public class ApplicationInsights : IApplicationInsights
 
     /// <inheritdoc />
     public async Task UpdateCfg(Config newConfig, bool? mergeExisting = true)
-        => await _jsRuntime.InvokeVoidAsync("appInsights.updateCfg", newConfig, mergeExisting);
+    {
+        var options = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        var configJson = JsonSerializer.Serialize(newConfig, options);
+
+        await _jsRuntime.InvokeVoidAsync("appInsights.updateCfg", configJson, mergeExisting);
+    }
 
     /// <inheritdoc />
     public async Task<TelemetryContext> Context()


### PR DESCRIPTION
Calling UpdateCfg would serialize all properties of the config object which would replace (set null) all the present values in the browser. Even when setting mergeExisting to true. By ignoring null values, existing settings would not be replaced with null when mergeExisting is true.

This fix makes it so you can use the configuration in index.html without overriding all the settings with null.