### PR TITLE
feat: WASM ILoggerProvider MinLogLevel support

### DIFF
--- a/src/BlazorApplicationInsights/Logging/ApplicationInsightsLogger.cs
+++ b/src/BlazorApplicationInsights/Logging/ApplicationInsightsLogger.cs
@@ -44,6 +44,9 @@ public class ApplicationInsightsLogger : ILogger
     /// <summary>Include scope information in CustomDimensions</summary>
     public bool IncludeScopes { get; set; }
 
+    /// <summary>Min LogLevel to write to app insights</summary>
+    public LogLevel MinLogLevel { get; set; }
+
     /// <summary>
     /// <para>Callback that will be called before customDimensions are set</para>
     /// <para>This allows enriching customDimensions with values that should apply to all log lines</para>
@@ -86,7 +89,7 @@ public class ApplicationInsightsLogger : ILogger
     }
 
     /// <inheritdoc />
-    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+    public bool IsEnabled(LogLevel logLevel) => this.MinLogLevel <= logLevel && logLevel != LogLevel.None;
 
     /// <inheritdoc />
     public IDisposable BeginScope<TState>(TState state) => ScopeProvider.Push(state);

--- a/src/BlazorApplicationInsights/Logging/ApplicationInsightsLoggerOptions.cs
+++ b/src/BlazorApplicationInsights/Logging/ApplicationInsightsLoggerOptions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace BlazorApplicationInsights;
@@ -19,8 +20,12 @@ public class ApplicationInsightsLoggerOptions
     /// <summary>Include scope information in customDimensions</summary>
     public bool IncludeScopes { get; set; } = true;
 
+    /// <summary>Min LogLevel to write to app insights defaults to Trace aka Verbose</summary>
+    public LogLevel MinLogLevel { get; set; } = LogLevel.Trace;
+
     [JsonIgnore]
     [Obsolete("Not part of the stable API")]
     [EditorBrowsable(EditorBrowsableState.Never)]
+
     public Action<Dictionary<string, object?>>? EnrichCallback { get; set; }
 }

--- a/src/BlazorApplicationInsights/Logging/ApplicationInsightsLoggerProvider.cs
+++ b/src/BlazorApplicationInsights/Logging/ApplicationInsightsLoggerProvider.cs
@@ -69,6 +69,7 @@ public class ApplicationInsightsLoggerProvider : ILoggerProvider, ISupportExtern
         return new ApplicationInsightsLogger(categoryName, _applicationInsights)
         {
             ScopeProvider = GetScopeProvider(),
+            MinLogLevel = _options.MinLogLevel,
             IncludeScopes = _options.IncludeScopes,
             IncludeCategoryName = _options.IncludeCategoryName,
 
@@ -98,6 +99,7 @@ public class ApplicationInsightsLoggerProvider : ILoggerProvider, ISupportExtern
             logger.ScopeProvider = scopeProvider;
             logger.IncludeCategoryName = options.IncludeCategoryName;
             logger.IncludeScopes = options.IncludeScopes;
+            logger.MinLogLevel = options.MinLogLevel;
 
 #pragma warning disable 618
             logger.EnrichmentCallback = _enrichmentCallback;


### PR DESCRIPTION
Example usage:
builder.Services.AddBlazorApplicationInsights(loggingOptions: (options) => options.MinLogLevel = LogLevel.Warning);