### PR TITLE
Provide services to initialization delegate

### DIFF
--- a/samples/BlazorApplicationInsights.Sample.Server/Program.cs
+++ b/samples/BlazorApplicationInsights.Sample.Server/Program.cs
@@ -21,7 +21,7 @@ namespace BlazorApplicationInsights.Sample.Server
             {
                 x.ConnectionString = "InstrumentationKey=219f9af4-0842-42c8-a5b1-578f09d2ee27;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/";
             },
-            async applicationInsights =>
+            async (_, applicationInsights) =>
             {
                 var telemetryItem = new TelemetryItem()
                 {

--- a/samples/BlazorApplicationInsights.Sample.Wasm/Program.cs
+++ b/samples/BlazorApplicationInsights.Sample.Wasm/Program.cs
@@ -18,7 +18,7 @@ namespace BlazorApplicationInsights.Sample.Wasm
             {
                 config.ConnectionString = "InstrumentationKey=219f9af4-0842-42c8-a5b1-578f09d2ee27;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/";
             },
-            async applicationInsights =>
+            async (_, applicationInsights) =>
             {
                 var telemetryItem = new TelemetryItem()
                 {

--- a/samples/BlazorApplicationInsights.Sample.Wasm6/Client/Program.cs
+++ b/samples/BlazorApplicationInsights.Sample.Wasm6/Client/Program.cs
@@ -19,7 +19,7 @@ namespace BlazorApplicationInsights.Sample.Wasm6
             {
                 config.ConnectionString = "InstrumentationKey=219f9af4-0842-42c8-a5b1-578f09d2ee27;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/";
             },
-            async applicationInsights =>
+            async (_, applicationInsights) =>
             {
                 var telemetryItem = new TelemetryItem()
                 {

--- a/src/BlazorApplicationInsights/ApplicationInsightsInitConfig.cs
+++ b/src/BlazorApplicationInsights/ApplicationInsightsInitConfig.cs
@@ -9,6 +9,6 @@ namespace BlazorApplicationInsights
     {
         public Config? Config { get; set; }
 
-        public Func<IApplicationInsights, Task>? OnAppInsightsInit { get; set; }
+        public Func<IServiceProvider, IApplicationInsights, Task>? OnAppInsightsInit { get; set; }
     }
 }

--- a/src/BlazorApplicationInsights/Components/ApplicationInsightsInit.razor.cs
+++ b/src/BlazorApplicationInsights/Components/ApplicationInsightsInit.razor.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using BlazorApplicationInsights.Interfaces;
@@ -12,6 +13,7 @@ namespace BlazorApplicationInsights;
 /// </summary>
 public partial class ApplicationInsightsInit
 {
+    [Inject] IServiceProvider ServiceProvider { get; set; }
     [Inject] IApplicationInsights ApplicationInsights { get; set; }
     [Inject] private IJSRuntime JSRuntime { get; set; }
     [Inject] private ApplicationInsightsInitConfig Config { get; set; }
@@ -54,7 +56,7 @@ public partial class ApplicationInsightsInit
 
         if (firstRender && Config.OnAppInsightsInit != null)
         {
-            await Config.OnAppInsightsInit(ApplicationInsights);
+            await Config.OnAppInsightsInit(ServiceProvider, ApplicationInsights);
         }
     }
 }

--- a/src/BlazorApplicationInsights/IServiceCollectionExtensions.cs
+++ b/src/BlazorApplicationInsights/IServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ public static class IServiceCollectionExtensions
     /// <param name="onAppInsightsInit">Callback which allows calling Application Insights commands on startup.  Note, requires component to be interactive!</param>
     /// <param name="addWasmLogger">Adds the ILoggerProvider which ships all logs to Application Insights. This is disabled on Blazor Server.</param>
     /// <param name="loggingOptions">Callback for configuring the logging options. Blazor WASM only.</param>
-    public static IServiceCollection AddBlazorApplicationInsights(this IServiceCollection services, Action<Config>? builder = null, Func<IApplicationInsights, Task>? onAppInsightsInit = null, bool addWasmLogger = true, Action<ApplicationInsightsLoggerOptions>? loggingOptions = null)
+    public static IServiceCollection AddBlazorApplicationInsights(this IServiceCollection services, Action<Config>? builder = null, Func<IServiceProvider, IApplicationInsights, Task>? onAppInsightsInit = null, bool addWasmLogger = true, Action<ApplicationInsightsLoggerOptions>? loggingOptions = null)
     {
         var initConfig = new ApplicationInsightsInitConfig();
 


### PR DESCRIPTION
Resolves #290 

Raising this draft to discuss desired approaches for maintaining backwards compatibility for the existing `Func<IApplicationInsights, Func>` delegate; if desired.