### PR TITLE
♻️ Init - UpdateCfg - Try catch

### DIFF
--- a/src/BlazorApplicationInsights/Components/ApplicationInsightsInit.razor.cs
+++ b/src/BlazorApplicationInsights/Components/ApplicationInsightsInit.razor.cs
@@ -1,8 +1,10 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using BlazorApplicationInsights.Interfaces;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 
 namespace BlazorApplicationInsights;
@@ -15,6 +17,7 @@ public partial class ApplicationInsightsInit
     [Inject] IApplicationInsights ApplicationInsights { get; set; }
     [Inject] private IJSRuntime JSRuntime { get; set; }
     [Inject] private ApplicationInsightsInitConfig Config { get; set; }
+    [Inject] private ILogger<ApplicationInsightsInit> Logger { get; set; }
 
     /// <summary>
     /// Must be enabled when running in Blazor Wasm Standalone
@@ -46,9 +49,15 @@ public partial class ApplicationInsightsInit
 
             if (Config.Config != null)
             {
-                await ApplicationInsights.UpdateCfg(Config.Config, false);
-
-                await ApplicationInsights.TrackPageView();
+                try
+                {
+                    await ApplicationInsights.UpdateCfg(Config.Config, false);
+                    await ApplicationInsights.TrackPageView();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "Failed to update configuration and track page view. An ad blocker or CSP may be blocking the App Insights script.");
+                }
             }
         }
 


### PR DESCRIPTION
A Content Security Policy or ad blocker may block downloading the `ai.3.gbl.min.js` file, but the init proceeds regardless. It will cause the dreaded red blazor error bar if the js file hasn't been downloaded. End users don't need to see an error here, so lets try catch, and log and error if one occurs, rather than leaving the exception unhandled.