### PR TITLE
feat: net9.0

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -35,7 +35,7 @@ jobs:
       shell: pwsh
 
     - name: Install Playwright
-      working-directory: tests/BlazorApplicationInsights.Tests/bin/Release/net8.0
+      working-directory: tests/BlazorApplicationInsights.Tests/bin/Release/net9.0
       run: ./playwright.ps1 install --with-deps
       shell: pwsh
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Application Insights for Blazor web applications
 
 ## Features
 
-- .NET 6/7/8 and Blazor Web App Support
+- .NET 6/7/8/9 and Blazor Web App Support
 - Automatically triggers Track Page View on route changes
 - ILoggerProvider which sends all the logs to App Insights (Wasm only)
 - Programmatically update settings, including the Connection String

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.203",
+    "version": "9.0.300",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.300",
+    "version": "9.0.200",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.200",
+    "version": "9.0.203",
     "rollForward": "latestFeature"
   }
 }

--- a/samples/BlazorApplicationInsights.Sample.Components/BlazorApplicationInsights.Sample.Components.csproj
+++ b/samples/BlazorApplicationInsights.Sample.Components/BlazorApplicationInsights.Sample.Components.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -25,6 +25,11 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.*" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/BlazorApplicationInsights.Sample.WebApp/BlazorApplicationInsights.Sample.WebApp.Client/BlazorApplicationInsights.Sample.WebApp.Client.csproj
+++ b/samples/BlazorApplicationInsights.Sample.WebApp/BlazorApplicationInsights.Sample.WebApp.Client/BlazorApplicationInsights.Sample.WebApp.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/BlazorApplicationInsights.Sample.WebApp/BlazorApplicationInsights.Sample.WebApp/BlazorApplicationInsights.Sample.WebApp.csproj
+++ b/samples/BlazorApplicationInsights.Sample.WebApp/BlazorApplicationInsights.Sample.WebApp/BlazorApplicationInsights.Sample.WebApp.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\BlazorApplicationInsights.Sample.WebApp.Client\BlazorApplicationInsights.Sample.WebApp.Client.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.*" />
   </ItemGroup>
 
 </Project>

--- a/src/BlazorApplicationInsights/BlazorApplicationInsights.csproj
+++ b/src/BlazorApplicationInsights/BlazorApplicationInsights.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Title>BlazorApplicationInsights</Title>
     <PackageId>BlazorApplicationInsights</PackageId>
@@ -46,6 +46,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/BlazorApplicationInsights.Tests/BlazorApplicationInsights.Tests.csproj
+++ b/tests/BlazorApplicationInsights.Tests/BlazorApplicationInsights.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.51.0" />
     <PackageReference Include="Moq" Version="4.20.71" />


### PR DESCRIPTION
I have made changes for the package to work on net9.0. Pretty straightforward, no code changes were needed. I have preserved backwards compatibility with net6.0 so there shouldnt be any regressions for older .net versions.

The tests do not run due to the connectionstring being invalid, but having tested that with my test environment's application insights connection string it worked just fine. I have however not committed the connection string for obvious reasons so the tests will likely continue to fail here.
